### PR TITLE
Scaling key frame time by frame rate.

### DIFF
--- a/Aseprite2Unity/Assets/Aseprite2Unity/Editor/AsepriteImporter.cs
+++ b/Aseprite2Unity/Assets/Aseprite2Unity/Editor/AsepriteImporter.cs
@@ -19,6 +19,7 @@ namespace Aseprite2Unity.Editor
         // Editor fields
         public float m_PixelsPerUnit = 100.0f;
         public SpriteAtlas m_SpriteAtlas;
+        public Material m_SpriteMaterial;
         public float m_FrameRate = 60.0f;
         public string m_SortingLayerName;
         public int m_SortingOrder;
@@ -95,6 +96,11 @@ namespace Aseprite2Unity.Editor
 
             var renderer = m_GameObject.AddComponent<SpriteRenderer>();
             renderer.sprite = m_Sprites[0];
+            if (m_SpriteMaterial != null)
+            {
+                renderer.material = m_SpriteMaterial;
+            }
+            
             renderer.sortingLayerName = m_SortingLayerName;
             renderer.sortingOrder = m_SortingOrder;
 

--- a/Aseprite2Unity/Assets/Aseprite2Unity/Editor/AsepriteImporterEditor.cs
+++ b/Aseprite2Unity/Assets/Aseprite2Unity/Editor/AsepriteImporterEditor.cs
@@ -46,6 +46,9 @@ namespace Aseprite2Unity.Editor
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("m_SpriteAtlas"),
                     new GUIContent("Sprite Atlas", "The sprites created by this import will be made part of this sprite atlas."));
 
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("m_SpriteMaterial"),
+                    new GUIContent("Sprite Material", "Material for the SpriteRenderer."));
+
                 DisplayStringChoiceProperty(serializedObject.FindProperty("m_SortingLayerName"),
                     SortingLayer.layers.Select(l => l.name).ToArray(),
                     new GUIContent("Sorting Layer", "Name of the SpriteRenderer's sorting layer."));


### PR DESCRIPTION
I found that changing `framerate` had no effect on animation playback speed (testing in `Unity 2020.3.25f1`). Multiplying the key time offset by `1 second / frame rate` fixes the issue.